### PR TITLE
Removed stale references to mu4e-dashboard-activate

### DIFF
--- a/dashboard.org
+++ b/dashboard.org
@@ -47,9 +47,6 @@ Type *C-c C-c* on the /CALL/ line below to evaluate your query.
 :VISIBILITY: hideall
 :END:
 
-Call [[elisp:mu4e-dashboard-activate][mu4e-dashboard-activate]] to activate automatic update and key bindings.
-Call [[elisp:mu4e-dashboard-deactivate][mu4e-dashboard-deactivate]] before editing the dashboard
-
 #+STARTUP: showall showstars indent
 
 #+NAME: query

--- a/side-dashboard.org
+++ b/side-dashboard.org
@@ -44,9 +44,6 @@
 :VISIBILITY: hideall
 :END:
 
-Call [[elisp:mu4e-dashboard-activate][mu4e-dashboard-activate]] to activate automatic update and key bindings.
-Call [[elisp:mu4e-dashboard-deactivate][mu4e-dashboard-deactivate]] before editing the dashboard
-
 #+STARTUP: showall showstars indent
 
 #+NAME: query


### PR DESCRIPTION
These references relate to an earlier version when mu4e-dashboard was not a
minor mode.

Closes: #20